### PR TITLE
Keep the animation playing at the original speed when encountering frame dropping.

### DIFF
--- a/ttr_ops.py
+++ b/ttr_ops.py
@@ -266,11 +266,16 @@ class TTR_Play(TTR_PlaySupport, Operator):
             bpy.ops.ttr.setup(op='UPD')
             return {'FINISHED'}
         elif event.type == 'TIMER':
-            if self.counter == self.frame_len:
-                self.counter = 0
-            self.frame = self.frames[self.counter]
-            self.frame_set(context.scene, self.frame)
-            self.counter += 1
+            if self.sync:
+                self.frame = self.frames[self.counter]
+                self.frame_set(context.scene, self.frame)
+                self.counter = int(round((time.time() - self.begin_time) / self.step))
+                self.counter %= self.frame_len
+            else:
+                self.frame = self.frames[self.counter]
+                self.frame_set(context.scene, self.frame)
+                self.counter += 1
+                self.counter %= self.frame_len
         return {'PASS_THROUGH'}
     
     def invoke(self, context, event):

--- a/ttr_support.py
+++ b/ttr_support.py
@@ -151,6 +151,8 @@ class TTR_PlaySupport(TTR_Helpers):
         self.main_sc.use_nodes = False
         self.frame_handler_remove()
         self.frame_len = len(self.frames)
+        self.sync = bpy.context.scene.sync_mode != 'NONE'
+        self.begin_time = time.time()
         self.counter = 0
         self.step = 1/int(self.main_sc.render.fps)
         self.wm = context.window_manager


### PR DESCRIPTION
When using "Frame Dropping" or "Sync to Audio" mode, the animation would maintain at the original speed when playing, even when encoutering frame dropping.